### PR TITLE
Add support for chained keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ Edit it by adding the following lines:
     Default value: '{"TV": "KEY_TV", "HDMI": "KEY_HDMI"}'<br/>
     Example value: '{"PlayStation": "KEY_HDMI1", "RaspberryPi": "KEY_HDMI2", "Chromecast": "KEY_HDMI3"}'<br/>
     You can also chain KEYS, example: '{"TV": "KEY_SOURCES+KEY_ENTER"}'<br/>
-    And even add delays (in milliseconds) between sending KEYS, example: '{"TV": "KEY_SOURCES+500+KEY_ENTER"}'<br/>
+    And even add delays (in milliseconds) between sending KEYS, example:<br/>
+    '{"TV": "KEY_SOURCES+500+KEY_ENTER"}'<br/>
     
     **app_list:**<br/>
     (json)(Optional)<br/>

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Edit it by adding the following lines:
     This contains the KEYS visible sources in the dropdown list in media player UI.<br/>
     Default value: '{"TV": "KEY_TV", "HDMI": "KEY_HDMI"}'<br/>
     Example value: '{"PlayStation": "KEY_HDMI1", "RaspberryPi": "KEY_HDMI2", "Chromecast": "KEY_HDMI3"}'<br/>
+    You can also chain KEYS, example: '{"TV": "KEY_SOURCES+KEY_ENTER"}'<br/>
+    And even add delays (in milliseconds) between sending KEYS, example: '{"TV": "KEY_SOURCES+500+KEY_ENTER"}'<br/>
     
     **app_list:**<br/>
     (json)(Optional)<br/>

--- a/custom_components/samsungtv_custom/media_player.py
+++ b/custom_components/samsungtv_custom/media_player.py
@@ -327,7 +327,7 @@ class SamsungTVDevice(MediaPlayerDevice):
                 return
 
             wakeonlan.send_magic_packet(self._mac)
-            #time.sleep(2)
+            time.sleep(2)
             self._ping_device()
         else:
             self.send_command("KEY_POWERON")

--- a/custom_components/samsungtv_custom/media_player.py
+++ b/custom_components/samsungtv_custom/media_player.py
@@ -9,6 +9,7 @@ import os
 import wakeonlan
 import websocket
 import requests
+import time
 
 from samsungtvws import SamsungTVWS
 
@@ -39,8 +40,6 @@ from homeassistant.const import (
 )
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import dt as dt_util
-
-import time
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
I had the same issue as described here:
https://github.com/roberodin/ha-samsungtv-custom/issues/16

Which is, only `KEY_HDMI` worked to toggle between HDMI sources.

I've tried: `KEY_TV`, `KEY_HDMI1`, `KEY_HDMI2`, `KEY_HDMI3`, `KEY_HDMI4`, `KEY_TV_MODE`, `KEY_PCMODE`, `KEY_ANTENA`, and many many others that I thought might be a fit.. none of them did anything.

I've also checked all over the internet for `samsung "KEY_"` in hopes I'd find some other lists of key codes that people posted, found many, but still no solution.

But! One coding project I found related to controlling Samsung TVs had a very interesting solution to this, which is to be able to support chained keys, for example:

`KEY_SOURCES+KEY_ENTER` would send the 2 key codes sequentially

`KEY_SOURCES+500+KEY_ENTER` would also send the 2 key codes sequentially, but with a 500ms delay between them, this further helps customisation, as some TVs might move slower then others

Chaining commands like this give amazing flexibility to this project, to support even the most knuckleheaded of Samsung TVs by going through their menus for the functionality you want.

I've used this implementation (not a python dev though, but a dev nonetheless) to fix changing sources on my TV.

Pinging @roberodin too, as he might also be interested, I can make a PR to his repo too if he agrees with the changes.

I also have a question though and this fork doesn't have the "Issues" tab active. I've exposed my Samsung TV to Google Assistant, but I only get the turn on / off options, I was expecting it to support volume and source changes with voice commands too, does anyone know why it isn't? (or if it's even possible to add?)